### PR TITLE
Use subprocess instead of time-limiting multiproc. separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ import securepy
 restrictor = securepy.Restrictor(
     time_limit=3,  # seconds
     restriction_scope=2,  # secure global scope
-    max_process_memory=5 * 1024 * 1024,  # 5 MB
-    max_output_memory=1_000_000,  # characters (byres): 1MB
-    output_chunk_read_size=1_000,  # characters (bytes): 1kB
+    max_process_memory=20 * 1024 * 1024,  # 20 MB
+    max_output_memory=10_000,  # 10,000 characters (bytes) maximum
+    output_chunk_read_size=1_000,  # characters (bytes)
     python_path="python"  # default `python` command in PATH
 )
 stdout, exc = restrictor.execute("""
@@ -43,9 +43,9 @@ stdout, exc = restrictor.execute("""
   - **1**: Restricted globals (removed some unsafe globals)
   - **2** (RECOMMENDED, default): Secure globals (only using relatively safe globals)
   - **3**: No globals (very limiting but quite safe)
-- `max_process_memory` is the maximum amount of RAM available to given process (default: 5MB)
-- `max_output_memory` is the maximum amount of memory allowed for STDOUT/STDERR outputs (default: 100kB)
-- `output_chunk_read_size` is the memory amount of a single chunk of stdout/stderr buffer to be read. (this buffer will keep being read until there's no more characters left or it gets bigger than specified `max_output_memory`) (default: 10kB)
+- `max_process_memory` is the maximum amount of RAM available to given process (default: 20MB)
+- `max_output_memory` is the maximum amount of memory allowed for STDOUT/STDERR outputs (default: 10,000 characters)
+- `output_chunk_read_size` is the memory amount of a single chunk of stdout/stderr buffer to be read. (this buffer will keep being read until there's no more characters left or it gets bigger than specified `max_output_memory`) (default: 1,000 characters)
 - `python_path` is the path to python executable used to run given code. This gives you the ability to use different non-default python versions. (default `python` as defined in PATH).
 
 ### Sandbox (NsJail)

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ In order to use this library, you must first download it from PyPi: `pip install
 import securepy
 
 restrictor = securepy.Restrictor(
-    max_exec_time=3,
-    restriction_scope=2,
-    max_process_memory=5_000_000,  # 5 MB
-    max_output_memory=100_000,  # characters (byres): 100kB
-    output_chunk_read_size=10_000,  # characters (bytes): 10kB
+    time_limit=3,  # seconds
+    restriction_scope=2,  # secure global scope
+    max_process_memory=5 * 1024 * 1024,  # 5 MB
+    max_output_memory=1_000_000,  # characters (byres): 1MB
+    output_chunk_read_size=1_000,  # characters (bytes): 1kB
     python_path="python"  # default `python` command in PATH
 )
 stdout, exc = restrictor.execute("""
@@ -37,7 +37,7 @@ stdout, exc = restrictor.execute("""
 """)
 ```
 
-- `max_exec_time` parameter is a way to specify the maximum amount of seconds the code will be allowed to run for until interruption. (required - int/float)
+- `time_limit` parameter is a way to specify the maximum amount of seconds the code will be allowed to run for until interruption. (required - int/float)
 - `restriction_scope` parameter is a way to specify how restricted the code should be. These are the currently available scopes:
   - **0**: No restriction (regular exec)
   - **1**: Restricted globals (removed some unsafe globals)

--- a/securepy/__init__.py
+++ b/securepy/__init__.py
@@ -1,7 +1,7 @@
 import securepy.config.config as _conf
 from securepy.limited_process import LimitedProcess  # noqa
 from securepy.restrictor import Restrictor  # noqa
-from securepy.security import get_globals  # noqa
+from securepy.security import get_safe_globals  # noqa
 from securepy.stdio import IOCage, MemoryOverflow, LimitedStringIO  # noqa
 from securepy.timing import IOTimedFunction, TimedFunction, TimedFunctionError  # noqa
 

--- a/securepy/__init__.py
+++ b/securepy/__init__.py
@@ -1,7 +1,7 @@
 import securepy.config.config as _conf
 from securepy.limited_process import LimitedProcess  # noqa
 from securepy.restrictor import Restrictor  # noqa
-from securepy.security import RESTRICTED_GLOBALS, SAFE_GLOBALS, UNRESTRICTED_GLOBALS  # noqa
+from securepy.security import get_globals  # noqa
 from securepy.stdio import IOCage, MemoryOverflow, LimitedStringIO  # noqa
 from securepy.timing import IOTimedFunction, TimedFunction, TimedFunctionError  # noqa
 

--- a/securepy/__init__.py
+++ b/securepy/__init__.py
@@ -2,7 +2,7 @@ import securepy.config.config as _conf
 from securepy.restrictor import Restrictor  # noqa
 from securepy.security import RESTRICTED_GLOBALS, SAFE_GLOBALS, UNRESTRICTED_GLOBALS  # noqa
 from securepy.stdio import IOCage, MemoryOverflow, read_process_output, LimitedStringIO  # noqa
-from securepy.timing import CapturingTimedFunction, TimedFunction, TimedFunctionError  # noqa
+from securepy.timing import IOTimedFunction, TimedFunction, TimedFunctionError  # noqa
 
 __title__ = _conf.NAME
 __author__ = _conf.AUTHOR

--- a/securepy/__init__.py
+++ b/securepy/__init__.py
@@ -1,7 +1,8 @@
 import securepy.config.config as _conf
+from securepy.limited_process import LimitedProcess  # noqa
 from securepy.restrictor import Restrictor  # noqa
 from securepy.security import RESTRICTED_GLOBALS, SAFE_GLOBALS, UNRESTRICTED_GLOBALS  # noqa
-from securepy.stdio import IOCage, MemoryOverflow, read_process_output, LimitedStringIO  # noqa
+from securepy.stdio import IOCage, MemoryOverflow, LimitedStringIO  # noqa
 from securepy.timing import IOTimedFunction, TimedFunction, TimedFunctionError  # noqa
 
 __title__ = _conf.NAME

--- a/securepy/__init__.py
+++ b/securepy/__init__.py
@@ -1,7 +1,7 @@
 import securepy.config.config as _conf
 from securepy.restrictor import Restrictor  # noqa
 from securepy.security import RESTRICTED_GLOBALS, SAFE_GLOBALS, UNRESTRICTED_GLOBALS  # noqa
-from securepy.stdio import IOCage, MemoryOverflow, read_process_std, LimitedStringIO  # noqa
+from securepy.stdio import IOCage, MemoryOverflow, read_process_output, LimitedStringIO  # noqa
 from securepy.timing import CapturingTimedFunction, TimedFunction, TimedFunctionError  # noqa
 
 __title__ = _conf.NAME

--- a/securepy/executor.py
+++ b/securepy/executor.py
@@ -1,7 +1,3 @@
-import sys
-
-from security import get_globals
-
 """
 This file will be run in subprocess and it's where the true code
 execution is happening.
@@ -11,7 +7,16 @@ the code that will be executed and the restriction level
 
 Example usage:
     `python securepy/executor.py [restriction_level] [code]`
+
+This also means that it will assume root of securepy/ hence
+the imports specified here won't need the `import securepy.module`
+but will instead only use `import module`.
 """
+
+import sys
+
+from security import get_globals
+
 
 if __name__ == "__main__":
     try:

--- a/securepy/executor.py
+++ b/securepy/executor.py
@@ -6,7 +6,7 @@ You need to provide system arguments to define,
 the code that will be executed and the restriction level
 
 Example usage:
-    `python securepy/executor.py [restriction_level] [code]`
+    `python securepy/executor.py [restriction_level] [memory_limit] [code]`
 
 This also means that it will assume root of securepy/ hence
 the imports specified here won't need the `import securepy.module`
@@ -14,17 +14,30 @@ but will instead only use `import module`.
 """
 
 import sys
+import warnings
 
 from security import get_safe_globals
+
+
+def mem_limit(max_virtual_memory: int) -> None:
+    if sys.platform in ["linux", "linux32", "darwin"]:
+        resource = __import__("resource")
+        resource.setrlimit(resource.RLIMIT_AS, (max_virtual_memory, resource.RLIM_INFINITY))
+    else:
+        warnings.warn("Your operating system doesn't support memory limitation, skipping memory limiting")
 
 
 if __name__ == "__main__":
     try:
         restriction_level = int(sys.argv[1])
-        code = sys.argv[2]
+        memory_limit = int(sys.argv[2])
+        code = sys.argv[3]
     except IndexError:
         raise RuntimeError("Warning, some arguments are missing.")
     except ValueError:
         raise RuntimeError("Warning, some arguments aren't correct.")
+
+    if memory_limit != -1:
+        mem_limit(memory_limit)
 
     exec(code, get_safe_globals(restriction_level))

--- a/securepy/executor.py
+++ b/securepy/executor.py
@@ -15,7 +15,7 @@ but will instead only use `import module`.
 
 import sys
 
-from security import get_globals
+from security import get_safe_globals
 
 
 if __name__ == "__main__":
@@ -27,4 +27,4 @@ if __name__ == "__main__":
     except ValueError:
         raise RuntimeError("Warning, some arguments aren't correct.")
 
-    exec(code, get_globals(restriction_level), {})
+    exec(code, get_safe_globals(restriction_level))

--- a/securepy/executor.py
+++ b/securepy/executor.py
@@ -16,7 +16,7 @@ but will instead only use `import module`.
 import sys
 import warnings
 
-from security import get_safe_globals
+from security import get_safe_globals  # type: ignore (Pylance can't recognize this import as it's using different workdir)
 
 
 def mem_limit(max_virtual_memory: int) -> None:

--- a/securepy/executor.py
+++ b/securepy/executor.py
@@ -1,0 +1,25 @@
+import sys
+
+from security import get_globals
+
+"""
+This file will be run in subprocess and it's where the true code
+execution is happening.
+
+You need to provide system arguments to define,
+the code that will be executed and the restriction level
+
+Example usage:
+    `python securepy/executor.py [restriction_level] [code]`
+"""
+
+if __name__ == "__main__":
+    try:
+        restriction_level = int(sys.argv[1])
+        code = sys.argv[2]
+    except IndexError:
+        raise RuntimeError("Warning, some arguments are missing.")
+    except ValueError:
+        raise RuntimeError("Warning, some arguments aren't correct.")
+
+    exec(code, get_globals(restriction_level), {})

--- a/securepy/limited_process.py
+++ b/securepy/limited_process.py
@@ -133,8 +133,8 @@ class LimitedProcess(subprocess.Popen):
 
         # All data exchanged.  Translate lists into strings.
         if stdout is not None:
-            stdout = stdout[0]
+            stdout = "".join(stdout)
         if stderr is not None:
-            stderr = stderr[0]
+            stderr = "".join(stderr)
 
         return (stdout, stderr)

--- a/securepy/limited_process.py
+++ b/securepy/limited_process.py
@@ -1,0 +1,140 @@
+import subprocess
+import sys
+import threading
+import typing as t
+
+from securepy.stdio import MemoryOverflow
+
+
+class ExcThread(threading.Thread):
+    """
+    This is an override for general `threading.Thread` class
+    in order to provide the ability to store exceptions
+    """
+    def run(self) -> None:
+        """
+        Method representing the thread's activity.
+
+        This method runs the provided `_target` function,
+        in case any exception occures in it, it will be stored
+        as `self.exc`
+        """
+        try:
+            if self._target:
+                self._target(*self._args, **self._kwargs)
+        except BaseException as e:
+            self.exc = e
+        finally:
+            # Avoid a refcycle if the thread is running a function with
+            # an argument that has a member that points to the thread.
+            del self._target, self._args, self._kwargs
+
+    def join(self, timeout: t.Optional[float]) -> None:
+        """
+        In case an exception has occured while the thread was running,
+        automatically raise it from this method.
+        """
+        # We shouldn't be getting any return value, but store it in case of overrides
+        ret = super().join(timeout=timeout)
+        if hasattr(self, "exc") and self.exc:
+            raise self.exc
+
+        return ret
+
+
+class LimitedProcess(subprocess.Popen):
+    _TXT = t.Union[bytes, str]
+    _CMD = t.Union[_TXT, t.Sequence[_TXT]]
+
+    def __init__(
+        self,
+        args: _CMD,
+        max_output_size: int,
+        read_chunk_size: int,
+        **kwargs
+    ) -> None:
+        super().__init__(args, **kwargs)
+
+        self.read_chunk_size = read_chunk_size
+        self.max_output_size = max_output_size
+        self.output_size = 0
+
+    def _readerthread(self, fh, buffer):
+        """
+        Read from STDOUT/STDERR inside of a thred
+        by chunks of `read_chunk_size` until EOF is hit
+        or we reach `max_output_size`.
+        """
+        while True:
+            out = fh.read(self.read_chunk_size)
+            self.output_size += sys.getsizeof(out)
+
+            if not out:  # "" or None
+                break
+
+            if self.output_size > self.max_output_size:
+                fh.close()
+                raise MemoryOverflow(
+                    used_memory=self.output_size,
+                    max_memory=self.max_output_size
+                )
+
+            buffer.append(out)
+        fh.close()
+
+    def _communicate(self, input, endtime, orig_timeout):
+        # Start reader threads feeding into a list hanging off of this
+        # object, unless they've already been started.
+        if self.stdout and not hasattr(self, "_stdout_buff"):
+            self._stdout_buff = []
+            self.stdout_thread = ExcThread(
+                target=self._readerthread,
+                args=(self.stdout, self._stdout_buff)
+            )
+            self.stdout_thread.daemon = True
+            self.stdout_thread.start()
+
+        if self.stderr and not hasattr(self, "_stderr_buff"):
+            self._stderr_buff = []
+            self.stderr_thread = ExcThread(
+                target=self._readerthread,
+                args=(self.stderr, self._stderr_buff)
+            )
+            self.stderr_thread.daemon = True
+            self.stderr_thread.start()
+
+        if self.stdin:
+            self._stdin_write(input)
+
+        # Wait for the reader threads, or time out. If we time out, the
+        # threads remain reading and the fds left open in case the user
+        # calls communicate again.
+        if self.stdout is not None:
+            self.stdout_thread.join(self._remaining_time(endtime))
+            if self.stdout_thread.is_alive():
+                raise subprocess.TimeoutExpired(self.args, orig_timeout)
+        if self.stderr is not None:
+            self.stderr_thread.join(self._remaining_time(endtime))
+            if self.stderr_thread.is_alive():
+                raise subprocess.TimeoutExpired(self.args, orig_timeout)
+
+        # Collect the output from and close both pipes, now that we know
+        # both have been read successfully.
+        stdout = None
+        stderr = None
+        if self.stdout:
+            if self._stdout_buff != []:
+                stdout = self._stdout_buff
+            self.stdout.close()
+        if self.stderr:
+            if self._stderr_buff != []:
+                stderr = self._stderr_buff
+            self.stderr.close()
+
+        # All data exchanged.  Translate lists into strings.
+        if stdout is not None:
+            stdout = stdout[0]
+        if stderr is not None:
+            stderr = stderr[0]
+
+        return (stdout, stderr)

--- a/securepy/limited_process.py
+++ b/securepy/limited_process.py
@@ -49,7 +49,7 @@ class LimitedProcess(subprocess.Popen):
     def __init__(
         self,
         args: _CMD,
-        max_output_size: int,
+        max_output_size: t.Optional[int],
         read_chunk_size: int,
         **kwargs
     ) -> None:
@@ -72,7 +72,7 @@ class LimitedProcess(subprocess.Popen):
             if not out:  # "" or None
                 break
 
-            if self.output_size > self.max_output_size:
+            if self.max_output_size is not None and self.output_size > self.max_output_size:
                 fh.close()
                 raise MemoryOverflow(
                     used_memory=self.output_size,

--- a/securepy/limited_process.py
+++ b/securepy/limited_process.py
@@ -20,14 +20,14 @@ class ExcThread(threading.Thread):
         as `self.exc`
         """
         try:
-            if self._target:
-                self._target(*self._args, **self._kwargs)
+            if self._target:  # type: ignore (Pylance doesn't recognize this variable)
+                self._target(*self._args, **self._kwargs)  # type: ignore (Pylance doesn't recognize these variables)
         except BaseException as e:
             self.exc = e
         finally:
             # Avoid a refcycle if the thread is running a function with
             # an argument that has a member that points to the thread.
-            del self._target, self._args, self._kwargs
+            del self._target, self._args, self._kwargs  # type: ignore (Pylance doesn't recognize these variables)
 
     def join(self, timeout: t.Optional[float]) -> None:
         """
@@ -53,7 +53,7 @@ class LimitedProcess(subprocess.Popen):
         read_chunk_size: int,
         **kwargs
     ) -> None:
-        super().__init__(args, **kwargs)
+        super().__init__(args, **kwargs)  # type: ignore (Pylance can't resolve Popen.__init__ properly)
 
         self.read_chunk_size = read_chunk_size
         self.max_output_size = max_output_size
@@ -104,17 +104,17 @@ class LimitedProcess(subprocess.Popen):
             self.stderr_thread.start()
 
         if self.stdin:
-            self._stdin_write(input)
+            self._stdin_write(input)  # type: ignore (Pylance doesn't recognize this variable)
 
         # Wait for the reader threads, or time out. If we time out, the
         # threads remain reading and the fds left open in case the user
         # calls communicate again.
         if self.stdout is not None:
-            self.stdout_thread.join(self._remaining_time(endtime))
+            self.stdout_thread.join(self._remaining_time(endtime))  # type: ignore (Pylance doesn't recognize this function)
             if self.stdout_thread.is_alive():
                 raise subprocess.TimeoutExpired(self.args, orig_timeout)
         if self.stderr is not None:
-            self.stderr_thread.join(self._remaining_time(endtime))
+            self.stderr_thread.join(self._remaining_time(endtime))  # type: ignore (Pylance doesn't recognize this function)
             if self.stderr_thread.is_alive():
                 raise subprocess.TimeoutExpired(self.args, orig_timeout)
 

--- a/securepy/restrictor.py
+++ b/securepy/restrictor.py
@@ -9,14 +9,14 @@ class Restrictor:
     def __init__(
         self,
         restriction_scope: t.Literal[1, 2, 3] = 2,
-        max_exec_time: t.Optional[t.Union[float, int]] = None,  # (seconds)
-        max_process_memory: t.Optional[int] = 5 * 1024 * 1024,  # 10 MB
-        max_output_memory: t.Optional[int] = 100_000,  # 100kB
+        time_limit: t.Optional[t.Union[float, int]] = None,  # seconds
+        max_process_memory: t.Optional[int] = 5 * 1024 * 1024,  # 5 MB
+        max_output_memory: t.Optional[int] = 1_000_000,  # 1MB
         output_chunk_read_size: int = 1_000,  # characters (bytes)
         python_path: str = "python"  # default to `python` in PATH
     ):
         """
-        `max_exec_time` is the maximum time limit in seconds for which exec function
+        `time_limit` is the maximum time limit in seconds for which exec function
         will be allowed to run. After this timelimit ends, exec will be terminated
         and `TimeoutError` will be raised.
 
@@ -42,7 +42,7 @@ class Restrictor:
         `python_path` is the path to python interpreter file which will be called to run the
         specified code.
         """
-        self.max_exec_time = max_exec_time
+        self.time_limit = time_limit
         self.restriction_scope = restriction_scope
         self.max_process_memory = max_process_memory if max_process_memory is not None else -1
         self.max_output_memory = max_output_memory
@@ -65,8 +65,8 @@ class Restrictor:
         )
 
         try:
-            # out = read_process_output(process, self.output_chunk_read_size, self.max_output_memory, self.max_exec_time)
-            stdout, stderr = process.communicate(timeout=self.max_exec_time)
+            # out = read_process_output(process, self.output_chunk_read_size, self.max_output_memory, self.time_limit)
+            stdout, stderr = process.communicate(timeout=self.time_limit)
         except MemoryOverflow as e:
             return subprocess.CompletedProcess(args, returncode=-1, stdout=None, stderr=str(e))
         except subprocess.TimeoutExpired as e:

--- a/securepy/restrictor.py
+++ b/securepy/restrictor.py
@@ -10,7 +10,7 @@ class Restrictor:
         self,
         restriction_scope: t.Literal[1, 2, 3] = 2,
         max_exec_time: t.Optional[t.Union[float, int]] = None,  # (seconds)
-        max_process_memory: t.Optional[int] = 5_000_000,  # 5MB
+        max_process_memory: t.Optional[int] = 5 * 1024 * 1024,  # 10 MB
         max_output_memory: t.Optional[int] = 100_000,  # 100kB
         output_chunk_read_size: int = 1_000,  # characters (bytes)
         python_path: str = "python"  # default to `python` in PATH
@@ -44,7 +44,7 @@ class Restrictor:
         """
         self.max_exec_time = max_exec_time
         self.restriction_scope = restriction_scope
-        self.max_process_memory = max_process_memory
+        self.max_process_memory = max_process_memory if max_process_memory is not None else -1
         self.max_output_memory = max_output_memory
         self.output_chunk_read_size = output_chunk_read_size
         self.python_path = python_path
@@ -52,7 +52,7 @@ class Restrictor:
     def execute(self, code: str) -> subprocess.CompletedProcess:
         args = [
             self.python_path, "securepy/executor.py",
-            str(self.restriction_scope), code
+            str(self.restriction_scope), str(self.max_process_memory), code
         ]
 
         process = LimitedProcess(

--- a/securepy/restrictor.py
+++ b/securepy/restrictor.py
@@ -7,10 +7,10 @@ from securepy.stdio import read_process_output
 class Restrictor:
     def __init__(
         self,
-        max_exec_time: int,
+        max_exec_time: t.Union[float, int],
         restriction_scope: t.Literal[1, 2, 3] = 2,
         max_process_memory: int = 5_000_000,  # 5MB
-        max_output_memory: int = 10_000,  # 100kB
+        max_output_memory: int = 100_000,  # 100kB
         output_chunk_read_size: int = 10_000,  # characters (bytes)
         python_path: str = "python"  # default to `python` in PATH
     ):

--- a/securepy/restrictor.py
+++ b/securepy/restrictor.py
@@ -7,11 +7,11 @@ from securepy.stdio import read_process_output
 class Restrictor:
     def __init__(
         self,
-        max_exec_time: t.Union[float, int],
         restriction_scope: t.Literal[1, 2, 3] = 2,
-        max_process_memory: int = 5_000_000,  # 5MB
-        max_output_memory: int = 100_000,  # 100kB
-        output_chunk_read_size: int = 10_000,  # characters (bytes)
+        max_exec_time: t.Optional[t.Union[float, int]] = None,  # (seconds)
+        max_process_memory: t.Optional[int] = 5_000_000,  # 5MB
+        max_output_memory: t.Optional[int] = 100_000,  # 100kB
+        output_chunk_read_size: int = 1_000,  # characters (bytes)
         python_path: str = "python"  # default to `python` in PATH
     ):
         """
@@ -26,11 +26,13 @@ class Restrictor:
         - 2 (RECOMMENDED): Secure globals (only using relatively safe builtins)
         - 3: No globals (very limiting but quite safe)
 
-        `max_process_memory` is the total amount of allowed memory single exec process can
-        use. Exceeding this will raise `MemoryOverflow`
+        `max_process_memory` is the total amount of allowed RAM memory single exec process
+        canuse. Exceeding this will raise `MemoryOverflow`. In case it's `None`, process
+        will run without RAM limitation.
 
         `max_output_memory` is the maximum allowed memory for STDOUT/STDERR of the process.
-        Exceeding this amount will raise `MemoryOverflow`
+        Exceeding this amount will raise `MemoryOverflow`. In case it's `None`, process
+        will run without STDOUT/STDERR memory limitation.
 
         `std_chunk_read_size` is the size (amount of characters) in bytes which will be used
         to read the single output chunk from given process, which will then be added to rest of
@@ -61,6 +63,7 @@ class Restrictor:
             process,
             self.output_chunk_read_size,
             self.max_output_memory,
+            self.max_exec_time
         )
 
         return out

--- a/securepy/restrictor.py
+++ b/securepy/restrictor.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import typing as t
 
@@ -48,10 +49,11 @@ class Restrictor:
         self.max_output_memory = max_output_memory
         self.output_chunk_read_size = output_chunk_read_size
         self.python_path = python_path
+        self.executable_path = os.path.dirname(os.path.realpath(__file__)) + "/executor.py"
 
     def execute(self, code: str) -> subprocess.CompletedProcess:
         args = [
-            self.python_path, "securepy/executor.py",
+            self.python_path, self.executable_path,
             str(self.restriction_scope), str(self.max_process_memory), code
         ]
 

--- a/securepy/restrictor.py
+++ b/securepy/restrictor.py
@@ -58,7 +58,7 @@ class Restrictor:
         ]
 
         process = LimitedProcess(
-            args,
+            args=args,  # type: ignore (Pylance can't resolve args properly)
             max_output_size=self.max_output_memory,
             read_chunk_size=self.output_chunk_read_size,
             stdout=subprocess.PIPE,

--- a/securepy/restrictor.py
+++ b/securepy/restrictor.py
@@ -11,8 +11,8 @@ class Restrictor:
         self,
         restriction_scope: t.Literal[1, 2, 3] = 2,
         time_limit: t.Optional[t.Union[float, int]] = None,  # seconds
-        max_process_memory: t.Optional[int] = 5 * 1024 * 1024,  # 5 MB
-        max_output_memory: t.Optional[int] = 1_000_000,  # 1MB
+        max_process_memory: t.Optional[int] = 20 * 1024 * 1024,  # 10 MB
+        max_output_memory: t.Optional[int] = 10_000,  # 10,000 characters (bytes) maximum
         output_chunk_read_size: int = 1_000,  # characters (bytes)
         python_path: str = "python"  # default to `python` in PATH
     ):

--- a/securepy/security.py
+++ b/securepy/security.py
@@ -96,7 +96,14 @@ for builtin, reference in vars(builtins).items():
         RESTRICTED_GLOBALS["__builtins__"][builtin] = reference
 
 
-def get_globals(restriction_level: int) -> dict:
+def get_safe_globals(restriction_level: int) -> dict:
+    """
+    Get secure globals based on given restriction level:
+    - 0: Unrestricted globals (full builtins as they are in this file)
+    - 1: Restricted globals (removed some unsafe builtins)
+    - 2 (RECOMMENDED): Secure globals (only using relatively safe builtins)
+    - 3: No globals (very limiting but quite safe)
+    """
     if restriction_level == 0:
         return deepcopy(UNRESTRICTED_GLOBALS)
     elif restriction_level == 1:

--- a/securepy/security.py
+++ b/securepy/security.py
@@ -1,5 +1,6 @@
 import builtins
 import typing as t
+from copy import deepcopy
 
 
 class ProtectionBreach(RuntimeError):
@@ -83,13 +84,13 @@ OVERRIDDEN_VALUES = {
 BASE_GLOBALS = {"__builtins__": {}}
 UNRESTRICTED_GLOBALS = {"__builtins__": builtins}
 
-SAFE_GLOBALS = BASE_GLOBALS.copy()
+SAFE_GLOBALS = deepcopy(BASE_GLOBALS)
 for name in SAFE_BUILTINS:
     SAFE_GLOBALS["__builtins__"][name] = getattr(builtins, name)
 for name, reference in OVERRIDDEN_VALUES.items():
     SAFE_GLOBALS["__builtins__"][name] = reference
 
-RESTRICTED_GLOBALS = BASE_GLOBALS.copy()
+RESTRICTED_GLOBALS = deepcopy(BASE_GLOBALS)
 for builtin, reference in vars(builtins).items():
     if builtin not in UNSAFE_BUILTINS:
         RESTRICTED_GLOBALS["__builtins__"][builtin] = reference

--- a/securepy/security.py
+++ b/securepy/security.py
@@ -98,12 +98,12 @@ for builtin, reference in vars(builtins).items():
 
 def get_globals(restriction_level: int) -> dict:
     if restriction_level == 0:
-        return UNRESTRICTED_GLOBALS
+        return deepcopy(UNRESTRICTED_GLOBALS)
     elif restriction_level == 1:
-        return RESTRICTED_GLOBALS
+        return deepcopy(RESTRICTED_GLOBALS)
     elif restriction_level == 2:
-        return SAFE_GLOBALS
+        return deepcopy(SAFE_GLOBALS)
     elif restriction_level == 3:
-        return BASE_GLOBALS
+        return deepcopy(BASE_GLOBALS)
     else:
         raise RuntimeError(f"Invalid `restriction_level` ({restriction_level}), valid values: 0-3.")

--- a/securepy/stdcapture.py
+++ b/securepy/stdcapture.py
@@ -7,10 +7,14 @@ from io import StringIO
 
 class MemoryOverflow(Exception):
     def __init__(self, used_memory: int, max_memory: int, message: t.Optional[str] = None, *args, **kwargs) -> None:
+        if not message:
+            message = "Maximum STDOUT/STDERR memory surpassed"
+        message += f"({used_memory} > {max_memory})"
+
         self.used_memory = used_memory
         self.max_memory = max_memory
-        if not message:
-            message = f"Maximum STDOUT/STDERR memory surpassed ({used_memory} > {max_memory})"
+        self.message = message
+
         super().__init__(message, *args, **kwargs)
 
 

--- a/securepy/stdcapture.py
+++ b/securepy/stdcapture.py
@@ -209,9 +209,8 @@ def read_process_std(
         stderr.append(chars)
 
         if output_size > max_size:
-            print("Output exceeded stdout limit, terminating NsJail with SIGKILL")
             process.kill()
-            break
+            raise MemoryOverflow(output_size, max_size, "Terminating subprocess.Popen with SIGKILL")
 
     # Wait for process termination
     process.wait()

--- a/securepy/stdcapture.py
+++ b/securepy/stdcapture.py
@@ -185,28 +185,23 @@ class StdCapture:
         return f"<StdCapture(stdout={self.stdout}, stderr={self.stderr})"
 
 
-def read_process_std(
+def read_process_output(
     process: subprocess.Popen,
     read_chunk_size: int,
     max_size: int,
-) -> t.Tuple[str, str]:
+) -> str:
     """
-    Start reading from STDOUT and STDERR, stop in case stdout limit is reached or process stops.
+    Start reading from STDOUT, stop in case stdout limit is reached or process stops.
 
     In case output from STDOUT will reach the max limit, the subprocess will be terminated by SIGKILL.
     """
     output_size = 0
     stdout = []
-    stderr = []
 
     while process.poll() is None:
-        chars = process.stdout.read(read_chunk_size)
-        output_size += sys.getsizeof(chars)
-        stdout.append(chars)
-
-        chars = process.stderr.read(read_chunk_size)
-        output_size += sys.getsizeof(chars)
-        stderr.append(chars)
+        stdout_chars = process.stdout.read(read_chunk_size)
+        output_size += sys.getsizeof(stdout_chars)
+        stdout.append(stdout_chars)
 
         if output_size > max_size:
             process.kill()
@@ -214,4 +209,4 @@ def read_process_std(
 
     # Wait for process termination
     process.wait()
-    return "".join(stdout), "".join(stderr)
+    return "".join(stdout)

--- a/securepy/stdio.py
+++ b/securepy/stdio.py
@@ -1,6 +1,4 @@
-import subprocess
 import sys
-import time
 import typing as t
 from functools import wraps
 from io import StringIO
@@ -217,43 +215,3 @@ class IOCage:
 
     def __repr__(self) -> str:
         return f"<IOCage(stdout={self.stdout}, stderr={self.stderr})"
-
-
-def read_process_output(
-    process: subprocess.Popen,
-    read_chunk_size: int = 1_000,
-    max_size: t.Optional[int] = None,
-    max_exec_time: t.Optional[t.Union[float, int]] = None
-) -> str:
-    """
-    Start reading from STDOUT of given `process`, return the obtained STDOUT as str.
-
-    In case `max_size` is specified, process will be terminated with SIGKILL if the obtained
-    output from STDOUT will get over specified `max_size` limit (in bytes).
-
-    In case `max_exec_time` is specified, process will be terminated with SIGKILL if the
-    given process will run over that specified time (in seconds).
-    """
-    output_size = 0
-    stdout = []
-    if max_exec_time is not None:
-        endtime = time.monotonic() + max_exec_time
-    else:
-        endtime = None
-
-    while process.poll() is None:
-        stdout_chars = process.stdout.read(read_chunk_size)
-        output_size += sys.getsizeof(stdout_chars)
-        stdout.append(stdout_chars)
-
-        if max_size is not None and output_size > max_size:
-            process.kill()
-            raise MemoryOverflow("Terminated subprocess.Popen with SIGKILL", output_size, max_size)
-
-        if endtime is not None and time.monotonic() > endtime:
-            process.kill()
-            raise TimeoutError(f"Terminated subprocess.Popen with SIGKILL (surpassed maximum time for execution: {max_exec_time})")
-
-    # Wait for process termination
-    process.wait()
-    return "".join(stdout)

--- a/securepy/stdio.py
+++ b/securepy/stdio.py
@@ -42,7 +42,7 @@ class IOCage:
     to given function it can work as a wrapper, decorator or context manager.
 
     Context Manager:
-        captured_std = IOCage(stdin='bye')  # `stdin` as a param to init. If not specified, `sys.stdin` will not be overrided
+        captured_std = IOCage(stdin='bye')  # `stdin` as a param to init. If not specified, STDIN won't be simulated.
         with captured_std:
             print("hello")
             print(input())  # Will print 'bye' to stdout

--- a/securepy/stdio.py
+++ b/securepy/stdio.py
@@ -236,7 +236,10 @@ def read_process_output(
     """
     output_size = 0
     stdout = []
-    start = time.time()
+    if max_exec_time is not None:
+        endtime = time.monotonic() + max_exec_time
+    else:
+        endtime = None
 
     while process.poll() is None:
         stdout_chars = process.stdout.read(read_chunk_size)
@@ -247,7 +250,7 @@ def read_process_output(
             process.kill()
             raise MemoryOverflow("Terminated subprocess.Popen with SIGKILL", output_size, max_size)
 
-        if max_exec_time is not None and time.time() - start > max_exec_time:
+        if endtime is not None and time.monotonic() > endtime:
             process.kill()
             raise TimeoutError(f"Terminated subprocess.Popen with SIGKILL (surpassed maximum time for execution: {max_exec_time})")
 

--- a/securepy/timing.py
+++ b/securepy/timing.py
@@ -45,7 +45,7 @@ class TimedFunction:
     you'll need to subclass and override `_capture_return` method and `_value_return`.
     """
 
-    def __init__(self, time_limit: int):
+    def __init__(self, time_limit: t.Union[float, int]):
         self.time_limit = time_limit
 
     def _capture_wrapper(self, func: t.Callable) -> t.Callable:
@@ -132,7 +132,7 @@ class TimedFunction:
             return self.run_timed(func, args, kwargs)
         return inner
 
-    def run_timed(self, func: t.Callable, args=None, kwargs=None) -> None:
+    def run_timed(self, func: t.Callable, args=None, kwargs=None) -> t.Any:
         """
         This is the method which actually handles the logic of running the given
         `func` for some specified time limit, using passed `args` and `kwargs` as

--- a/securepy/timing.py
+++ b/securepy/timing.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import multiprocessing.pool
 import typing as t
+import warnings
 from functools import wraps
 
 from securepy.stdio import IOCage, LimitedStringIO
@@ -189,7 +190,7 @@ class IOTimedFunction(TimedFunction):
     def __init__(self, time_limit: int, io_cage: IOCage):
         super().__init__(time_limit)
         self.io_cage = io_cage
-        raise DeprecationWarning("This class is deprecated, it might cause issues with multiprocessing.")
+        warnings.warn("This class is deprecated, it might cause issues with multiprocessing.")
 
     def _capture_return(self, func: t.Callable, *args, **kwargs) -> t.Tuple[t.Literal["exc", "ret"], t.Any, LimitedStringIO, LimitedStringIO]:
         """

--- a/tests/test_stdio.py
+++ b/tests/test_stdio.py
@@ -228,6 +228,6 @@ class IOCageTests(unittest.TestCase):
                 warnings.warn("Test")
 
         self.assertEqual(internal.stderr, "")
-        self.assertEqual(external.stderr, "")
+        self.assertIn('warnings.warn("Test")', external.stderr)
 
     # endregion


### PR DESCRIPTION
## Abstract

Until now, SecurePy wasn't really separating the code execution in any significant way, the only separation from the main process was there due to the use of `multiprocessing` with timed functions. Even though this meant that the execution process was technically running in a different process, multiprocessing doesn't give us total separation from the main process and in certain cases, it was possible to crash the main process using the multiprocessing separated process, which is unacceptable.

Another issue with multiprocessing was properly getting the output (STDOUT/STDERR) and exception handling, especially in a secure buffer-limited way. Even though this might be possible to do properly, it's not worth it as there is a better and easier alternative.

## Advantages for subprocess

### Raising C exception in a python

```py
def foo():
    try:
        foo()
    except RecursionError:
        foo()

foo()
```
in this case, multiprocessing wouldn't be able to handle this and the main process would collapse with the original one making it a security issue.

### Total program memory limitation

```py
def mem_limit(max_virtual_memory: int) -> None:
    if sys.platform in ["linux", "linux32", "darwin"]:
        resource = __import__("resource")
        resource.setrlimit(resource.RLIMIT_AS, (max_virtual_memory, resource.RLIM_INFINITY))
    else:
        warnings.warn("Your operating system doesn't support memory limitation, skipping memory limiting")
```
Even though Windows systems don't fully support this, at least on UNIX-based systems, it will be possible to directly set the memory limit of the whole python process. This would be completely impossible with the multiprocessing approach because it would also limit the memory in the main process.

### Different python interpreter

Using multiprocessing, it's possible to specify a different executable file that will be used to run the python file which will execute the given code, this is done by a simple keyword argument to restrictor: `python_path="/usr/bin/custom_python"`.
