### PR TITLE
Add issue auto-lable workflow

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,22 @@
+name: issue-automation
+
+on:
+  issues:
+    types: [opened, labeled, unlabeled]
+
+jobs:
+  triage-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: If no labels, add triage
+        id: no-labels
+        uses: andymckay/labeler@master
+        if: ${{ join(github.event.issue.labels.*.name, ',') == '' }}
+        with:
+          add-labels: 'triage'
+
+      - name: If labeled, remove triage
+        uses: andymckay/labeler@master
+        if: ${{ steps.no-labels.outcome == 'skipped' && join(github.event.issue.labels.*.name, ',') != 'triage' }}
+        with:
+          remove-labels: 'triage'


### PR DESCRIPTION
Automate adding `triage` label for newly opened issues, to mark them ready to be classified by repository maintainers